### PR TITLE
Feat/iobject cache

### DIFF
--- a/src/dig/Program.cs
+++ b/src/dig/Program.cs
@@ -1,6 +1,4 @@
-using chia.dotnet;
 using dig;
-using Microsoft.AspNetCore.DataProtection;
 using System.CommandLine;
 using System.CommandLine.Builder;
 using System.CommandLine.Parsing;
@@ -10,38 +8,11 @@ var builder = Host.CreateApplicationBuilder(args);
 
 // the non-web app builder doesn't bind to settings files automatically
 var path = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "appsettings.json");
-builder.Configuration.AddJsonFile(path, optional: true);
-builder.Configuration.AddJsonFile(appStorage.UserSettingsFilePath, optional: true);
+builder.Configuration.AddJsonFile(path, optional: true)
+    .AddJsonFile(appStorage.UserSettingsFilePath, optional: true);
 
-// configure services
-builder.Services.AddSingleton<StoreManager>()
-    .AddSingleton<DynDnsService>()
-    .AddSingleton<HostManager>()
-    .AddSingleton<LoginManager>()
-    .AddSingleton<ChiaConfig>()
-    .AddSingleton<DnsService>()
-    .AddSingleton<ContextBinder>()
-    .AddSingleton<NodeSyncService>()
-    .AddSingleton<ChiaService>()
-    .AddSingleton<StoreService>()
-    .AddSingleton<StorePreCacheService>()
-    .AddSingleton<FileCacheService>()
-    .AddSingleton<ServerCoinService>()
-    .AddSingleton((provider) => appStorage)
-    .AddHttpClient()
-    .RegisterChiaEndPoint<DataLayerProxy>("dig.server")
-    .RegisterChiaEndPoint<FullNodeProxy>("dig.server")
-    .RegisterChiaEndPoint<WalletProxy>("dig.server")
-    .AddDataProtection()
-    .SetApplicationName("distributed-internet-gateway")
-    .SetDefaultKeyLifetime(TimeSpan.FromDays(180));
-
-builder.Services.AddHttpClient("datalayer.storage", c =>
-    {
-        c.BaseAddress = new Uri(builder.Configuration.GetValue("dig:DataLayerStorageUri", "https://api.datalayer.storage")!);
-    });
-
-var host = builder.Build();
+var host = builder.ConfigureServices(appStorage)
+    .Build();
 
 return await new CommandLineBuilder(new RootCommand("Utilities to manage the chia data layer distributed internet gateway."))
     .UseDefaults()

--- a/src/dig/ServiceConfiguration.cs
+++ b/src/dig/ServiceConfiguration.cs
@@ -1,0 +1,40 @@
+using chia.dotnet;
+using dig.caching;
+using Microsoft.AspNetCore.DataProtection;
+
+namespace dig;
+
+public static class ServiceConfiguration
+{
+    public static HostApplicationBuilder ConfigureServices(this HostApplicationBuilder builder, AppStorage appStorage)
+    {
+        builder.Services.AddSingleton<StoreManager>()
+            .AddSingleton<DynDnsService>()
+            .AddSingleton<HostManager>()
+            .AddSingleton<LoginManager>()
+            .AddSingleton<ChiaConfig>()
+            .AddSingleton<DnsService>()
+            .AddSingleton<ContextBinder>()
+            .AddSingleton<NodeSyncService>()
+            .AddSingleton<ChiaService>()
+            .AddSingleton<StoreService>()
+            .AddSingleton<StorePreCacheService>()
+            .AddSingleton<FileCacheService>()
+            .AddSingleton<ServerCoinService>()
+            .AddSingleton((provider) => appStorage)
+            .AddHttpClient()
+            .RegisterChiaEndPoint<DataLayerProxy>("dig.node")
+            .RegisterChiaEndPoint<FullNodeProxy>("dig.node")
+            .RegisterChiaEndPoint<WalletProxy>("dig.node")
+            .AddDataProtection()
+            .SetApplicationName("distributed-internet-gateway")
+            .SetDefaultKeyLifetime(TimeSpan.FromDays(180));
+
+        builder.Services.AddHttpClient("datalayer.storage", c =>
+            {
+                c.BaseAddress = new Uri(builder.Configuration.GetValue("dig:DataLayerStorageUri", "https://api.datalayer.storage")!);
+            });
+
+        return builder;
+    }
+}

--- a/src/dig/Services/StorePreCacheService.cs
+++ b/src/dig/Services/StorePreCacheService.cs
@@ -1,27 +1,28 @@
 using System.Web;
 using chia.dotnet;
+using dig.caching;
 
 namespace dig;
 
 public class StorePreCacheService(DataLayerProxy dataLayer,
-                                    FileCacheService fileCache,
+                                    IObjectCache objectCacheService,
                                     ILogger<StorePreCacheService> logger,
                                     IConfiguration configuration)
 {
     private readonly DataLayerProxy _dataLayer = dataLayer;
-    private readonly FileCacheService _fileCache = fileCache;
+    private readonly IObjectCache _objectCacheService = objectCacheService;
     private readonly ILogger<StorePreCacheService> _logger = logger;
     private readonly IConfiguration _configuration = configuration;
 
     public async Task CacheStore(string storeId, CancellationToken cancellationToken)
     {
-        _fileCache.RemoveStore(storeId);
+        _objectCacheService.RemoveStore(storeId);
 
         var rootHash = await _dataLayer.GetRoot(storeId, cancellationToken);
-        await _fileCache.SetValueAsync(storeId, "", "last-root", rootHash, cancellationToken);
+        await _objectCacheService.SetValueAsync(storeId, "", "last-root", rootHash, cancellationToken);
 
         var storeKeys = await _dataLayer.GetKeys(storeId, rootHash.Hash, cancellationToken) ?? [];
-        await _fileCache.SetValueAsync(storeId, rootHash.Hash, "keys", storeKeys, cancellationToken);
+        await _objectCacheService.SetValueAsync(storeId, rootHash.Hash, "keys", storeKeys, cancellationToken);
 
         foreach (var key in storeKeys)
         {
@@ -29,14 +30,14 @@ public class StorePreCacheService(DataLayerProxy dataLayer,
             var value = await _dataLayer.GetValue(storeId, key, rootHash.Hash, cancellationToken);
             if (value != null)
             {
-                await _fileCache.SetValueAsync(storeId, rootHash.Hash, key, value, cancellationToken);
+                await _objectCacheService.SetValueAsync(storeId, rootHash.Hash, key, value, cancellationToken);
             }
 
             if (!_configuration.GetValue("dig:DisableProofOfInclusion", true))
             {
                 _logger.LogInformation("Pre-caching proof of {key} for storeId {storeId}.", key.SanitizeForLog(), storeId.SanitizeForLog());
                 var proof = await _dataLayer.GetProof(storeId, [HttpUtility.UrlDecode(key)], cancellationToken);
-                await _fileCache.SetValueAsync(storeId, rootHash.Hash, key, proof.ToJson(), cancellationToken);
+                await _objectCacheService.SetValueAsync(storeId, rootHash.Hash, key, proof.ToJson(), cancellationToken);
             }
         }
     }

--- a/src/server/Program.cs
+++ b/src/server/Program.cs
@@ -1,14 +1,10 @@
 using Microsoft.Extensions.Logging.Configuration;
 using Microsoft.Extensions.Logging.EventLog;
 using dig;
+using dig.server;
 
 var appStorage = new AppStorage(".dig");
 var builder = WebApplication.CreateBuilder(args);
-
-if (builder.Environment.IsProduction())
-{
-    builder.Services.AddApplicationInsightsTelemetry();
-}
 
 if (OperatingSystem.IsWindows())
 {
@@ -19,8 +15,8 @@ var path = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "appsettings.json
 if (File.Exists(path))
 {
     Console.WriteLine($"Loading settings from {path}");
+    builder.Configuration.AddJsonFile(path, optional: true);
 }
-builder.Configuration.AddJsonFile(path, optional: true);
 
 // we can take the path to an appsettings.json file as an argument
 // if not provided, the default appsettings.json will be used and settings
@@ -35,6 +31,8 @@ else if (File.Exists(appStorage.UserSettingsFilePath))
     Console.WriteLine($"Loading user settings from {appStorage.UserSettingsFilePath}");
     builder.Configuration.AddJsonFile(appStorage.UserSettingsFilePath, optional: true);
 }
+
+builder.ConfigureServices(appStorage);
 
 var app = builder.Build();
 

--- a/src/server/ServiceConfiguration.cs
+++ b/src/server/ServiceConfiguration.cs
@@ -10,6 +10,11 @@ public static class ServiceConfiguration
 {
     public static WebApplicationBuilder ConfigureServices(this WebApplicationBuilder builder, AppStorage appStorage)
     {
+        if (builder.Environment.IsProduction())
+        {
+            builder.Services.AddApplicationInsightsTelemetry();
+        }
+
         builder.Services.AddControllersWithViews(options =>
         {
             options.Filters.AddService<FooterDataFilter>();
@@ -28,7 +33,7 @@ public static class ServiceConfiguration
             .AddSingleton<ServerCoinService>()
             .AddSingleton<ChiaService>()
             .AddScoped<FooterDataFilter>()
-            .AddScoped<IViewEngine, RazorViewEngine>()
+            .AddScoped<IViewEngine, RazorViewEngine>() // we use this so we can check for the existence of a view by name
             .AddMemoryCache()
             .RegisterChiaEndPoint<DataLayerProxy>("dig.server")
             .RegisterChiaEndPoint<FullNodeProxy>("dig.server")
@@ -43,7 +48,7 @@ public static class ServiceConfiguration
         // this is where configuration based services are added
         //
 
-        switch (builder.Configuration.GetValue("dig:CacheProvider", "FileSystem"))
+        switch (builder.Configuration.GetValue("dig:CacheProvider", "Disabled"))
         {
             case "Memory":
                 builder.Services.AddSingleton<IObjectCache, MemoryCacheService>();

--- a/src/server/ServiceConfiguration.cs
+++ b/src/server/ServiceConfiguration.cs
@@ -1,0 +1,96 @@
+using chia.dotnet;
+using Microsoft.AspNetCore.Mvc.ViewEngines;
+using Microsoft.AspNetCore.Mvc.Razor;
+using dig.caching;
+using Microsoft.AspNetCore.DataProtection;
+
+namespace dig.server;
+
+public static class ServiceConfiguration
+{
+    public static WebApplicationBuilder ConfigureServices(this WebApplicationBuilder builder, AppStorage appStorage)
+    {
+        builder.Services.AddControllersWithViews(options =>
+        {
+            options.Filters.AddService<FooterDataFilter>();
+        });
+        builder.Services.AddRazorPages();
+
+        builder.Services.AddSingleton<ChiaConfig>()
+            .AddHttpClient()
+            .AddSingleton((provider) => appStorage)
+            .AddHostedService<ServerService>()
+            .AddSingleton<GatewayService>()
+            .AddSingleton<MirrorService>()
+            .AddSingleton<DnsService>()
+            .AddSingleton<StoreRegistryService>()
+            .AddSingleton<MeshNetworkRoutingService>()
+            .AddSingleton<ServerCoinService>()
+            .AddSingleton<ChiaService>()
+            .AddScoped<FooterDataFilter>()
+            .AddScoped<IViewEngine, RazorViewEngine>()
+            .AddMemoryCache()
+            .RegisterChiaEndPoint<DataLayerProxy>("dig.server")
+            .RegisterChiaEndPoint<FullNodeProxy>("dig.server")
+            .RegisterChiaEndPoint<WalletProxy>("dig.server");
+
+        builder.Services.AddHttpClient("datalayer.storage", c =>
+        {
+            c.BaseAddress = new Uri(builder.Configuration.GetValue("dig:DataLayerStorageUri", "https://api.datalayer.storage/")!);
+        }).AddStandardResilienceHandler();
+
+        //
+        // this is where configuration based services are added
+        //
+
+        switch (builder.Configuration.GetValue("dig:CacheProvider", "FileSystem"))
+        {
+            case "Memory":
+                builder.Services.AddSingleton<IObjectCache, MemoryCacheService>();
+                break;
+            case "FileSystem":
+                builder.Services.AddSingleton<IObjectCache, FileCacheService>();
+                break;
+            case "Disabled":
+                builder.Services.AddSingleton<IObjectCache, NullCacheService>();
+                break;
+            default:
+                throw new NotImplementedException($"Cache provider {builder.Configuration.GetValue("dig: CacheProvider", "FileSystem")} not implemented");
+        }
+
+        // this sets up the sync service - note that it shares some dependencies with the gateway service
+        // ChiaConfig, RpcClientHost, and DataLayerProxy
+        if (builder.Configuration.GetValue("dig:NodeSyncJobEnabled", false))
+        {
+            builder.Services
+                .AddHostedService<PeriodicNodeSyncService>()
+                .AddSingleton<NodeSyncService>()
+                .AddSingleton<StoreService>()
+                .AddSingleton<DnsService>();
+        }
+
+        // setup the Dyn Dns service
+        if (builder.Configuration.GetValue("dig:DynDnsJobEnabled", false))
+        {
+            builder.Services
+                .AddHostedService<PeriodicDynDnsService>()
+                .AddSingleton<DynDnsService>()
+                .AddSingleton<DnsService>()
+                .AddSingleton<LoginManager>()
+                .AddDataProtection()
+                .SetApplicationName("distributed-internet-gateway")
+                .SetDefaultKeyLifetime(TimeSpan.FromDays(180));
+        }
+
+        if (builder.Configuration.GetValue("dig:RunAsWindowsService", false))
+        {
+            builder.Services.AddWindowsService(options =>
+                {
+                    options.ServiceName = "Distributed Internet Gateway";
+                });
+            builder.Host.UseWindowsService(); // safe to call on non-windows platforms
+        }
+
+        return builder;
+    }
+}

--- a/src/server/Services/MeshNetworkRoutingService.cs
+++ b/src/server/Services/MeshNetworkRoutingService.cs
@@ -56,10 +56,10 @@ public class MeshNetworkRoutingService(ChiaConfig chiaConfig,
 
     /**
     * Fetches data from a mesh network of URLs associated with a store ID and an optional key.
-    * The first URL in the list is prioritized since the first url is usually the store owner, 
-    * followed by a randomized order of HTTPS URLs, then domain-named URLs, and finally any 
-    * remaining URLs, also randomized. This hurestic sorts the url list in a best guess order of reliability.
-    * 
+    * The first URL in the list is prioritized since the first url is usually the store owner,
+    * followed by a randomized order of HTTPS URLs, then domain-named URLs, and finally any
+    * remaining URLs, also randomized. This heuristic sorts the url list in a best guess order of reliability.
+    *
     * @param storeId The store ID for which to fetch the data.
     * @param key An optional key for the specific data to fetch.
     * @param returnRedirectUrl A flag indicating whether to return the redirect URL instead of the content.
@@ -83,7 +83,7 @@ public class MeshNetworkRoutingService(ChiaConfig chiaConfig,
         var remainingUrls = urls.Except(httpsUrls).Except(domainNamedUrls).Except(new[] { firstUrl }).OrderBy(_ => Guid.NewGuid());
 
         // Combine all sorted and filtered URLs
-        var orderedUrls = (new[] { firstUrl }).Concat(httpsUrls).Concat(domainNamedUrls).Concat(remainingUrls).Where(url => url != null && !_cache.TryGetValue(url, out _));
+        var orderedUrls = (new[] { firstUrl }).Concat(httpsUrls).Concat(domainNamedUrls).Concat(remainingUrls).Where(url => url is not null && !_cache.TryGetValue(url, out _));
 
         foreach (var url in orderedUrls)
         {
@@ -122,7 +122,8 @@ public class MeshNetworkRoutingService(ChiaConfig chiaConfig,
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Error checking URL {url}", apiUrl.SanitizeForLog());
-                _cache.Set(url, false, TimeSpan.FromHours(1));
+                // nulls are filtered out above, so we can safely cache the failed URL
+                _cache.Set(url!, false, TimeSpan.FromHours(1));
             }
         }
 

--- a/src/shared/Services/Caching/FileCacheService.cs
+++ b/src/shared/Services/Caching/FileCacheService.cs
@@ -28,7 +28,7 @@ public class FileCacheService : IObjectCache
         }
 
         // it's not cached so create it and add it to the file cache if it's not null
-            _logger.LogWarning("File cache miss for {key}", key.SanitizeForLog());
+        _logger.LogWarning("File cache miss for {key}", key.SanitizeForLog());
         var newValue = await factory();
 
         if (newValue is not null)

--- a/src/shared/Services/Caching/FileCacheService.cs
+++ b/src/shared/Services/Caching/FileCacheService.cs
@@ -1,8 +1,8 @@
 using chia.dotnet;
 
-namespace dig;
+namespace dig.caching;
 
-public class FileCacheService
+public class FileCacheService : IObjectCache
 {
     private readonly string _cacheDirectory;
     private readonly ILogger<FileCacheService> _logger;
@@ -28,7 +28,7 @@ public class FileCacheService
         }
 
         // it's not cached so create it and add it to the file cache if it's not null
-        _logger.LogWarning("File cache miss for {key}", key.SanitizeForLog());
+            _logger.LogWarning("File cache miss for {key}", key.SanitizeForLog());
         var newValue = await factory();
 
         if (newValue is not null)

--- a/src/shared/Services/Caching/IObjectCache.cs
+++ b/src/shared/Services/Caching/IObjectCache.cs
@@ -1,0 +1,10 @@
+namespace dig.caching;
+
+public interface IObjectCache
+{
+    Task<TItem?> GetOrCreateAsync<TItem>(string storeId, string rootHash, string key, Func<Task<TItem>> factory, CancellationToken token);
+    Task<TItem?> GetValueAsync<TItem>(string storeId, string rootHash, string key, CancellationToken token);
+    Task SetValueAsync<TItem>(string storeId, string rootHash, string key, TItem? value, CancellationToken token);
+    void RemoveStore(string storeId);
+    void Clear();
+}

--- a/src/shared/Services/Caching/MemoryCacheService.cs
+++ b/src/shared/Services/Caching/MemoryCacheService.cs
@@ -70,8 +70,8 @@ public class MemoryCacheService(IMemoryCache memoryCache,
 
     public void RemoveStore(string storeId)
     {
-        // since the cache key includes the store and the root hash this shouldn't be necessary
-        // for the memory cache, which doesn't support bulk removal
+        // since the cache key includes the store and the root hash this
+        // is ok to be a no-op for the memory cache, which doesn't support bulk removal
         //
         // orphaned keys will be removed by the sliding expiration
         // and the cache reset token

--- a/src/shared/Services/Caching/MemoryCacheService.cs
+++ b/src/shared/Services/Caching/MemoryCacheService.cs
@@ -4,7 +4,7 @@ using Microsoft.Extensions.Primitives;
 namespace dig.caching;
 
 /// <summary>
-/// The cache service that does not caching. Used to disable caching altogether.
+/// This cache service uses the built-in .NET Core memory cache to store objects in memory.
 /// </summary>
 public class MemoryCacheService(IMemoryCache memoryCache,
                                 ILogger<MemoryCacheService> logger,

--- a/src/shared/Services/Caching/MemoryCacheService.cs
+++ b/src/shared/Services/Caching/MemoryCacheService.cs
@@ -1,0 +1,79 @@
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Primitives;
+
+namespace dig.caching;
+
+/// <summary>
+/// The cache service that does not caching. Used to disable caching altogether.
+/// </summary>
+public class MemoryCacheService(IMemoryCache memoryCache,
+                                ILogger<MemoryCacheService> logger,
+                                IConfiguration configuration) : IObjectCache
+{
+    private readonly IMemoryCache _memoryCache = memoryCache;
+    private readonly ILogger<MemoryCacheService> _logger = logger;
+    private readonly IConfiguration _configuration = configuration;
+    private CancellationTokenSource _cacheResetToken = new();
+    private readonly object _lock = new();
+
+    public async Task<TItem?> GetOrCreateAsync<TItem>(string storeId, string rootHash, string key, Func<Task<TItem>> factory, CancellationToken token)
+    {
+        var cacheKey = string.Concat(storeId, rootHash, key).MD5Hash();
+        return await _memoryCache.GetOrCreateAsync(cacheKey, async (entry) =>
+        {
+            _logger.LogWarning("Memory cache miss for {key}", key.SanitizeForLog());
+
+            // this allows us to reset the cache when we want to
+            entry.AddExpirationToken(new CancellationChangeToken(_cacheResetToken.Token));
+            entry.SlidingExpiration = TimeSpan.FromMinutes(_configuration.GetValue("dig:MemoryCacheSlidingExpirationMinutes", 15));
+            return await factory();
+        });
+    }
+
+    public async Task<TItem?> GetValueAsync<TItem>(string storeId, string rootHash, string key, CancellationToken token)
+    {
+        var cacheKey = string.Concat(storeId, rootHash, key).MD5Hash();
+
+        if (_memoryCache.TryGetValue(cacheKey, out TItem? value))
+        {
+            return value;
+        }
+
+        await Task.CompletedTask;
+
+        return default;
+    }
+
+    public async Task SetValueAsync<TItem>(string storeId, string rootHash, string key, TItem? value, CancellationToken token)
+    {
+        var cacheKey = string.Concat(storeId, rootHash, key).MD5Hash();
+
+        var cacheEntryOptions = new MemoryCacheEntryOptions()
+            .AddExpirationToken(new CancellationChangeToken(_cacheResetToken.Token));
+
+        cacheEntryOptions.SlidingExpiration = TimeSpan.FromMinutes(_configuration.GetValue("dig:MemoryCacheSlidingExpirationMinutes", 15));
+
+        _memoryCache.Set(cacheKey, value, cacheEntryOptions);
+
+        await Task.CompletedTask;
+    }
+
+    public void Clear()
+    {
+        lock (_lock)
+        {
+            _cacheResetToken.Cancel();
+            _cacheResetToken.Dispose();
+            _cacheResetToken = new CancellationTokenSource();
+        }
+    }
+
+    public void RemoveStore(string storeId)
+    {
+        // since the cache key includes the store and the root hash this shouldn't be necessary
+        // for the memory cache, which doesn't support bulk removal
+        //
+        // orphaned keys will be removed by the sliding expiration
+        // and the cache reset token
+    }
+}

--- a/src/shared/Services/Caching/NullCacheService.cs
+++ b/src/shared/Services/Caching/NullCacheService.cs
@@ -1,7 +1,7 @@
 namespace dig.caching;
 
 /// <summary>
-/// The cache service that does not caching. Used to disable caching altogether.
+/// The cache service that does not actually cache anything. Used to disable caching altogether.
 /// </summary>
 public class NullCacheService : IObjectCache
 {

--- a/src/shared/Services/Caching/NullCacheService.cs
+++ b/src/shared/Services/Caching/NullCacheService.cs
@@ -5,23 +5,11 @@ namespace dig.caching;
 /// </summary>
 public class NullCacheService : IObjectCache
 {
+    public async Task<TItem?> GetOrCreateAsync<TItem>(string storeId, string rootHash, string key, Func<Task<TItem>> factory, CancellationToken token) => await factory();
 
-    public async Task<TItem?> GetOrCreateAsync<TItem>(string storeId, string rootHash, string key, Func<Task<TItem>> factory, CancellationToken token)
-    {
-        return await factory();
-    }
+    public async Task<TItem?> GetValueAsync<TItem>(string storeId, string rootHash, string key, CancellationToken token) => await Task.FromResult(default(TItem));
 
-    public async Task<TItem?> GetValueAsync<TItem>(string storeId, string rootHash, string key, CancellationToken token)
-    {
-        await Task.CompletedTask;
-
-        return default;
-    }
-
-    public async Task SetValueAsync<TItem>(string storeId, string rootHash, string key, TItem? value, CancellationToken token)
-    {
-        await Task.CompletedTask;
-    }
+    public async Task SetValueAsync<TItem>(string storeId, string rootHash, string key, TItem? value, CancellationToken token) => await Task.CompletedTask;
 
     public void Clear()
     {

--- a/src/shared/Services/Caching/NullCacheService.cs
+++ b/src/shared/Services/Caching/NullCacheService.cs
@@ -1,0 +1,33 @@
+namespace dig.caching;
+
+/// <summary>
+/// The cache service that does not caching. Used to disable caching altogether.
+/// </summary>
+public class NullCacheService : IObjectCache
+{
+
+    public async Task<TItem?> GetOrCreateAsync<TItem>(string storeId, string rootHash, string key, Func<Task<TItem>> factory, CancellationToken token)
+    {
+        return await factory();
+    }
+
+    public async Task<TItem?> GetValueAsync<TItem>(string storeId, string rootHash, string key, CancellationToken token)
+    {
+        await Task.CompletedTask;
+
+        return default;
+    }
+
+    public async Task SetValueAsync<TItem>(string storeId, string rootHash, string key, TItem? value, CancellationToken token)
+    {
+        await Task.CompletedTask;
+    }
+
+    public void Clear()
+    {
+    }
+
+    public void RemoveStore(string storeId)
+    {
+    }
+}

--- a/src/shared/appsettings.examples.json
+++ b/src/shared/appsettings.examples.json
@@ -21,6 +21,7 @@
     "dig": {
         "Comment": "This is the complete list of configurable settings.",
         "ChiaCertDirectory": "C:\\some_fully_qualified_path\\mainnet\\config\\ssl\\",
+        "CacheProvider": "<Memory or FileSystem (default) or Disabled>",
         "FullNodeHost": "hostname_or_ip",
         "FullNodePort": 8555,
         "WalletHost": "hostname_or_ip",

--- a/src/shared/shared.projitems
+++ b/src/shared/shared.projitems
@@ -9,7 +9,10 @@
         <Import_RootNamespace>shared</Import_RootNamespace>
     </PropertyGroup>
     <ItemGroup>
-        <Compile Include="$(MSBuildThisFileDirectory)Services\FileCacheService.cs" />
+        <Compile Include="$(MSBuildThisFileDirectory)Services\Caching\FileCacheService.cs" />
+        <Compile Include="$(MSBuildThisFileDirectory)Services\Caching\NullCacheService.cs" />
+        <Compile Include="$(MSBuildThisFileDirectory)Services\Caching\MemoryCacheService.cs" />
+        <Compile Include="$(MSBuildThisFileDirectory)Services\Caching\IObjectCache.cs" />
         <Compile Include="$(MSBuildThisFileDirectory)Services\ServerCoinService.cs" />
         <Compile Include="$(MSBuildThisFileDirectory)Services\StoreService.cs" />
         <Compile Include="$(MSBuildThisFileDirectory)Services\MirrorService.cs" />


### PR DESCRIPTION
This adds configrable cache provider. Currently

- FileSystem (the default)
- Memory 
- Disabled

Set in the config like so

```
    "dig": {
        "CacheProvider": "Disabled"
    }
```

New providers, like one for redis, need to implement `IObjectCache` and then need a setting and instantiation.

```
        switch (builder.Configuration.GetValue("dig:CacheProvider", "Disabled"))
        {
            case "Memory":
                builder.Services.AddSingleton<IObjectCache, MemoryCacheService>();
                break;
            case "FileSystem":
                builder.Services.AddSingleton<IObjectCache, FileCacheService>();
                break;
            case "Disabled":
                builder.Services.AddSingleton<IObjectCache, NullCacheService>();
                break;
            default:
                throw new NotImplementedException($"Cache provider {builder.Configuration.GetValue("dig: CacheProvider", "FileSystem")} not implemented");
        }
```
