### PR TITLE
Feat/network service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -403,3 +403,4 @@ FodyWeavers.xsd
 
 # JetBrains Rider
 *.sln.iml
+.mono/registry/CurrentUser/software/microsoft/csdevkit/v1/pids/52951_133551895400070624/values.xml

--- a/.mono/registry/CurrentUser/software/microsoft/csdevkit/telemetry/persistentpropertybag/values.xml
+++ b/.mono/registry/CurrentUser/software/microsoft/csdevkit/telemetry/persistentpropertybag/values.xml
@@ -1,0 +1,3 @@
+﻿<values>
+  <value name="mac.address" type="string">c938dbf44d565cf628f843d3fe60895e67ac701d160fd21b9fd93f29c107b31a</value>
+</values>

--- a/.mono/registry/CurrentUser/software/microsoft/sqmclient/values.xml
+++ b/.mono/registry/CurrentUser/software/microsoft/sqmclient/values.xml
@@ -1,0 +1,3 @@
+﻿<values>
+  <value name="MachineId" type="string">{C938DBF4-4D56-5CF6-28F8-43D3FE60895E}</value>
+</values>

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -208,6 +208,18 @@
       "envFile": "${workspaceFolder}/.env"
     },
     {
+      "name": "dig.server - Service",
+      "type": "coreclr",
+      "request": "launch",
+      "preLaunchTask": "build",
+      "program": "${workspaceFolder}/src/server/bin/Debug/net8.0/dig.server.dll",
+      "cwd": "${workspaceFolder}/src/server",
+      "console": "integratedTerminal",
+      "args": ["c:\\Users\\Don\\.dig\\appsettings.user.json"],
+      "stopAtEntry": false,
+      "envFile": "${workspaceFolder}/.env"
+    },
+    {
       "name": ".NET Core Attach",
       "type": "coreclr",
       "request": "attach"

--- a/build-msi.ps1
+++ b/build-msi.ps1
@@ -4,7 +4,7 @@ $outputRoot = "./publish"
 
 # build the msi - win-x64 only
 if ([System.Environment]::OSVersion.Platform -eq "Win32NT") {
-    & ./publish.ps1 win-x64
+    # & ./publish.ps1 win-x64
 
     dotnet build ./$src/Installer/Windows/MsiInstaller.wixproj -c Release -r win-x64 --output $outputRoot
     Move-Item -Path $outputRoot/en-us/Distributed-Internet-Gateway.msi -Destination $outputRoot/$name-win-x64.msi

--- a/build-msi.ps1
+++ b/build-msi.ps1
@@ -2,10 +2,10 @@ $name = "Distributed-Internet-Gateway"
 $src = "src"
 $outputRoot = "./publish"
 
+# build the msi - win-x64 only
 if ([System.Environment]::OSVersion.Platform -eq "Win32NT") {
-    #& ./publish.ps1 win-x64
+    & ./publish.ps1 win-x64
 
-    # build the msi - win-x64 only
     dotnet build ./$src/Installer/Windows/MsiInstaller.wixproj -c Release -r win-x64 --output $outputRoot
     Move-Item -Path $outputRoot/en-us/Distributed-Internet-Gateway.msi -Destination $outputRoot/$name-win-x64.msi
 }

--- a/src/Installer/Windows/GrantPermissions.ps1
+++ b/src/Installer/Windows/GrantPermissions.ps1
@@ -16,8 +16,8 @@ $jsonString = $jsonContent | ConvertTo-Json -Depth 2
 $filePath = Join-Path -Path $digFolder -ChildPath "appsettings.user.json"
 $jsonString | Out-File -FilePath $filePath
 
-# Grant NetworkService modification access to .dig folder
-icacls $digFolder /grant "NT AUTHORITY\NetworkService:(M)" /T
+# Grant NetworkService full control to .dig folder
+icacls "$digFolder" /grant:r "NT AUTHORITY\NetworkService:(OI)(CI)(F)" /T
 
 # Check if CHIA_ROOT environment variable exists and points to a folder
 $chiaRoot = $env:CHIA_ROOT

--- a/src/Installer/Windows/GrantPermissions.ps1
+++ b/src/Installer/Windows/GrantPermissions.ps1
@@ -1,0 +1,33 @@
+# Create a folder named .dig in the user's home directory
+$digFolder = "$env:USERPROFILE\.dig"
+if (-not (Test-Path $digFolder)) {
+    New-Item -ItemType Directory -Path $digFolder | Out-Null
+}
+
+# create the user settings file with default cache directory location
+$cachePath = Join-Path -Path $digFolder -ChildPath "store-cache"
+$jsonContent = @{
+    "dig" = @{
+        "CacheProvider"      = "FileSystem"
+        "FileCacheDirectory" = $cachePath
+    }
+}
+$jsonString = $jsonContent | ConvertTo-Json -Depth 2
+$filePath = Join-Path -Path $digFolder -ChildPath "appsettings.user.json"
+$jsonString | Out-File -FilePath $filePath
+
+# Grant NetworkService modification access to .dig folder
+icacls $digFolder /grant "NT AUTHORITY\NetworkService:(M)" /T
+
+# Check if CHIA_ROOT environment variable exists and points to a folder
+$chiaRoot = $env:CHIA_ROOT
+$chiaMainnetFolder = Join-Path $env:USERPROFILE ".chia\mainnet"
+if ($chiaRoot -and (Test-Path $chiaRoot)) {
+    # Grant NetworkService modification access to CHIA_ROOT folder
+    icacls $chiaRoot /grant "NT AUTHORITY\NetworkService:(M)" /T
+}
+# if not CHIA_ROOT set, check if ~/.chia/mainnet/ folder exists
+elseif (Test-Path $chiaMainnetFolder) {
+    # Grant NetworkService modification access to ~/.chia/mainnet/ folder
+    icacls $chiaMainnetFolder /grant "NT AUTHORITY\NetworkService:(M)" /T
+}

--- a/src/Installer/Windows/GrantPermissions.ps1
+++ b/src/Installer/Windows/GrantPermissions.ps1
@@ -13,7 +13,7 @@ $jsonContent = @{
     }
 }
 $jsonString = $jsonContent | ConvertTo-Json -Depth 2
-$filePath = Join-Path -Path $digFolder -ChildPath "appsettings.user.json"
+$filePath = Join-Path -Path $digFolder -ChildPath "appsettings.json"
 $jsonString | Out-File -FilePath $filePath
 
 # Grant NetworkService full control to .dig folder

--- a/src/Installer/Windows/Package.wxs
+++ b/src/Installer/Windows/Package.wxs
@@ -57,7 +57,7 @@
                 <RemoveFile Id="ALLFILES" Name="*.*" On="both" />
 
                 <!-- Tell WiX to install the Service -->
-                <ServiceInstall Id="ServiceInstaller" Type="ownProcess" Name="DistributedInternetGateway" DisplayName="$(Name)" Description="The Distributed Internet Gateway expresses chia as a webite." Start="auto" Account="NT AUTHORITY\NETWORK SERVICE" ErrorControl="normal" Arguments='"[%HOMEDRIVE][%HOMEPATH]\.dig\appsettings.user.json"'/>
+                <ServiceInstall Id="ServiceInstaller" Type="ownProcess" Name="DistributedInternetGateway" DisplayName="$(Name)" Description="The Distributed Internet Gateway expresses chia as a webite." Start="auto" Account="NT AUTHORITY\NETWORK SERVICE" ErrorControl="normal" Arguments='"[%HOMEDRIVE][%HOMEPATH]\.dig\appsettings.json"'/>
 
                 <!-- Tell WiX to start the Service -->
                 <ServiceControl Id="StartService" Start="install" Stop="both" Remove="uninstall" Name="DistributedInternetGateway" Wait="true"/>

--- a/src/Installer/Windows/Package.wxs
+++ b/src/Installer/Windows/Package.wxs
@@ -3,9 +3,9 @@
 <!--
     This will install dig.server.exe as a Windows Service
     and use the current user name to set the config file path.
-    The service runs as local system but will use that config file
+    The service runs as netwrok service but will use that config file
 
-    sc.exe config "Distributed-Internet-Gateway" binPath="C:\Program Files\<path to>\dig.server.exe <full path to config file>"
+    The GrantPermissions.ps1 file is used to set the permissions on the config file
 -->
 
 <!-- Define the variables in "$(var.*) expressions" -->
@@ -46,6 +46,9 @@
             <Component Id="WebConfig">
                 <File Id="web.config" Source="$(var.SourcePath)\web.config" KeyPath="true" />
             </Component>
+            <Component Id="GrantPermissions">
+                <File Id="GrantPermissions.ps1" Source=".\GrantPermissions.ps1" KeyPath="true" />
+            </Component>
             <Component Id="ServiceExecutable" Bitness="always64">
                 <!-- Copies the dig.server.exe file using the project reference preprocessor variables -->
                 <File Id="dig.server.exe" Source="$(var.SourcePath)\dig.server.exe" KeyPath="true" />
@@ -54,7 +57,7 @@
                 <RemoveFile Id="ALLFILES" Name="*.*" On="both" />
 
                 <!-- Tell WiX to install the Service -->
-                <ServiceInstall Id="ServiceInstaller" Type="ownProcess" Name="DistributedInternetGateway" DisplayName="$(Name)" Description="The Distributed Internet Gateway expresses chia as a webite." Start="auto" Account="LocalSystem" ErrorControl="normal" Arguments='"[%HOMEDRIVE][%HOMEPATH]\.dig\appsettings.user.json"'/>
+                <ServiceInstall Id="ServiceInstaller" Type="ownProcess" Name="DistributedInternetGateway" DisplayName="$(Name)" Description="The Distributed Internet Gateway expresses chia as a webite." Start="auto" Account="NT AUTHORITY\NETWORK SERVICE" ErrorControl="normal" Arguments='"[%HOMEDRIVE][%HOMEPATH]\.dig\appsettings.user.json"'/>
 
                 <!-- Tell WiX to start the Service -->
                 <ServiceControl Id="StartService" Start="install" Stop="both" Remove="uninstall" Name="DistributedInternetGateway" Wait="true"/>
@@ -68,6 +71,7 @@
         <!-- Tell WiX to install the files -->
         <Feature Id="Service" Title="Distributed Internet Gateway Service Setup" Level="1">
             <ComponentRef Id="ServiceExecutable" />
+            <ComponentRef Id="GrantPermissions" />
             <ComponentRef Id="AppSettings" />
             <ComponentRef Id="CLI" />
             <ComponentRef Id="ServerCoinExe" />
@@ -89,6 +93,16 @@
             <ComponentRef Id="Twittersocialiconscirclebluepng" />
             <ComponentRef Id="Twittersocialiconscirclewhitepng" />
         </Feature>
+
+        <Property Id="POWERSHELLCMD">
+            <RegistrySearch Id="FindPowershell" Root="HKLM" Key="SOFTWARE\Microsoft\PowerShell\1\ShellIds\Microsoft.PowerShell" Name="Path" Type="raw" />
+        </Property>
+
+        <CustomAction Id="SetServicePermissions" Property="POWERSHELLCMD" ExeCommand="-WindowStyle Hidden -ExecutionPolicy Bypass -File &quot;[INSTALLFOLDER]GrantPermissions.ps1&quot;" Execute="deferred" Return="check" Impersonate="yes" />
+
+        <InstallExecuteSequence>
+            <Custom Action="SetServicePermissions" After="InstallFiles" Condition="NOT Installed"/>
+        </InstallExecuteSequence>
 
     </Package>
 

--- a/src/Installer/Windows/Package.wxs
+++ b/src/Installer/Windows/Package.wxs
@@ -92,6 +92,7 @@
             <ComponentRef Id="swarmjpg" />
             <ComponentRef Id="Twittersocialiconscirclebluepng" />
             <ComponentRef Id="Twittersocialiconscirclewhitepng" />
+            <ComponentRef Id="eekjpg" />
         </Feature>
 
         <Property Id="POWERSHELLCMD">

--- a/src/Installer/Windows/PurgeInstall.ps1
+++ b/src/Installer/Windows/PurgeInstall.ps1
@@ -1,0 +1,26 @@
+# if you you hav e trouble uninstalling refer to this
+# https://stackoverflow.com/questions/26739524/wix-toolset-complete-cleanup-after-disallowing-uninstallation-of-component-sin
+#
+
+$productName = "Distributed Internet Gateway"  # this should basically match against your previous
+# installation path. Make sure that you don't mess with other components used
+# by any other MSI package
+
+$components = Get-ChildItem -Path HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\
+$count = 0
+
+foreach ($c in $components)
+{
+    foreach($p in $c.Property)
+    {
+        $propValue = (Get-ItemProperty "Registry::$($c.Name)" -Name "$($p)")."$($p)"
+        if ($propValue -match $productName)
+        {
+            Write-Output $propValue
+            $count++
+            Remove-Item "Registry::$($c.Name)" -Recurse
+        }
+    }
+}
+
+Write-Host "$($count) key(s) removed"

--- a/src/Installer/Windows/wwwroot.wxi
+++ b/src/Installer/Windows/wwwroot.wxi
@@ -54,6 +54,9 @@
             <Component Id="Twittersocialiconscirclewhitepng">
                 <File Id="file_Twittersocialiconscirclewhitepng" Source="$(var.SourcePath)\wwwroot\images\Twitter social icons - circle - white.png" KeyPath="yes" />
             </Component>
+            <Component Id="eekjpg">
+                <File Id="file_eekjpg" Source="$(var.SourcePath)\wwwroot\images\eek.jpg" KeyPath="yes" />
+            </Component>
         </Directory>
 
         <Directory Id="wwwroot.js" Name="js"></Directory>

--- a/src/Installer/Windows/wwwroot.wxi
+++ b/src/Installer/Windows/wwwroot.wxi
@@ -2,56 +2,56 @@
 <?define SourcePath="..\..\..\publish\standalone\win-x64" ?>
 <Include xmlns="http://wixtoolset.org/schemas/v4/wxs">
     <Directory Id="wwwroot" Name="wwwroot">
-        <Component Id="androidchrome192x192png" Guid="473EF349-1C94-49B6-AE56-CC11E3CE4FAF">
+        <Component Id="androidchrome192x192png">
             <File Id="file_androidchrome192x192png" Source="$(var.SourcePath)\wwwroot\android-chrome-192x192.png" KeyPath="yes" />
         </Component>
-        <Component Id="androidchrome512x512png" Guid="0E8BF100-3A20-4E71-83FC-262C0AFBEA63">
+        <Component Id="androidchrome512x512png">
             <File Id="file_androidchrome512x512png" Source="$(var.SourcePath)\wwwroot\android-chrome-512x512.png" KeyPath="yes" />
         </Component>
-        <Component Id="appletouchiconpng" Guid="894BB48A-C13A-48DF-8759-287C79ADCE71">
+        <Component Id="appletouchiconpng">
             <File Id="file_appletouchiconpng" Source="$(var.SourcePath)\wwwroot\apple-touch-icon.png" KeyPath="yes" />
         </Component>
-        <Component Id="browserconfigxml" Guid="0EAD5A8B-A251-4DE0-8832-4F65D0BCFAF4">
+        <Component Id="browserconfigxml">
             <File Id="file_browserconfigxml" Source="$(var.SourcePath)\wwwroot\browserconfig.xml" KeyPath="yes" />
         </Component>
-        <Component Id="favicon16x16png" Guid="87FD1C3F-D745-4C68-8EDB-0647C5A1C1AD">
+        <Component Id="favicon16x16png">
             <File Id="file_favicon16x16png" Source="$(var.SourcePath)\wwwroot\favicon-16x16.png" KeyPath="yes" />
         </Component>
-        <Component Id="favicon32x32png" Guid="3FF21DB9-0A7E-4416-8443-44E4A3E88B5E">
+        <Component Id="favicon32x32png">
             <File Id="file_favicon32x32png" Source="$(var.SourcePath)\wwwroot\favicon-32x32.png" KeyPath="yes" />
         </Component>
-        <Component Id="faviconico" Guid="62D2F8A2-7AA9-4581-A2FD-46AD0B28AFFC">
+        <Component Id="faviconico">
             <File Id="file_faviconico" Source="$(var.SourcePath)\wwwroot\favicon.ico" KeyPath="yes" />
         </Component>
-        <Component Id="mstile150x150png" Guid="12275E99-D633-43AB-B3E7-94A7BB69FD42">
+        <Component Id="mstile150x150png">
             <File Id="file_mstile150x150png" Source="$(var.SourcePath)\wwwroot\mstile-150x150.png" KeyPath="yes" />
         </Component>
-        <Component Id="safaripinnedtabsvg" Guid="4D0695D9-F8FD-4E49-8D40-6896CFFBD14D">
+        <Component Id="safaripinnedtabsvg">
             <File Id="file_safaripinnedtabsvg" Source="$(var.SourcePath)\wwwroot\safari-pinned-tab.svg" KeyPath="yes" />
         </Component>
-        <Component Id="sitewebmanifest" Guid="096A66DE-F7A9-49C3-8B90-9961372A34F4">
+        <Component Id="sitewebmanifest">
             <File Id="file_sitewebmanifest" Source="$(var.SourcePath)\wwwroot\site.webmanifest" KeyPath="yes" />
         </Component>
         <Directory Id="wwwroot.css" Name="css">
-            <Component Id="stylev1css" Guid="B551A36E-D41D-4962-B93A-D745DF4308BD">
+            <Component Id="stylev1css">
                 <File Id="file_stylev1css" Source="$(var.SourcePath)\wwwroot\css\style.v1.css" KeyPath="yes" />
             </Component>
         </Directory>
 
         <Directory Id="wwwroot.images" Name="images">
-            <Component Id="githubmarkwhitepng" Guid="44CEC257-2A82-426A-9C58-B9046F77B546">
+            <Component Id="githubmarkwhitepng">
                 <File Id="file_githubmarkwhitepng" Source="$(var.SourcePath)\wwwroot\images\github-mark-white.png" KeyPath="yes" />
             </Component>
-            <Component Id="githubmarkpng" Guid="40699580-7BD6-4C2F-857D-6636166019E6">
+            <Component Id="githubmarkpng">
                 <File Id="file_githubmarkpng" Source="$(var.SourcePath)\wwwroot\images\github-mark.png" KeyPath="yes" />
             </Component>
-            <Component Id="swarmjpg" Guid="560A2BF2-77DC-4369-97C3-DDA55EBF49AD">
+            <Component Id="swarmjpg">
                 <File Id="file_swarmjpg" Source="$(var.SourcePath)\wwwroot\images\swarm.jpg" KeyPath="yes" />
             </Component>
-            <Component Id="Twittersocialiconscirclebluepng" Guid="D58797FA-BC30-431C-9149-C4F8310740BA">
+            <Component Id="Twittersocialiconscirclebluepng">
                 <File Id="file_Twittersocialiconscirclebluepng" Source="$(var.SourcePath)\wwwroot\images\Twitter social icons - circle - blue.png" KeyPath="yes" />
             </Component>
-            <Component Id="Twittersocialiconscirclewhitepng" Guid="02E029A9-025A-4713-B900-278E51A61148">
+            <Component Id="Twittersocialiconscirclewhitepng">
                 <File Id="file_Twittersocialiconscirclewhitepng" Source="$(var.SourcePath)\wwwroot\images\Twitter social icons - circle - white.png" KeyPath="yes" />
             </Component>
         </Directory>

--- a/src/dig/Program.cs
+++ b/src/dig/Program.cs
@@ -2,16 +2,26 @@ using dig;
 using System.CommandLine;
 using System.CommandLine.Builder;
 using System.CommandLine.Parsing;
+using Microsoft.Extensions.Logging.Configuration;
+using Microsoft.Extensions.Logging.EventLog;
 
 var appStorage = new AppStorage(".dig");
 var builder = Host.CreateApplicationBuilder(args);
 
 // the non-web app builder doesn't bind to settings files automatically
-var path = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "appsettings.json");
+// this block looks for three settings files in order of precedence:
+// 1. appsettings.json in the app's base directory
+// 2. appsettings.json in the user's settings directory
+// 3. appsettings.user.json in the user's settings directory
+builder.Configuration
+    .AddJsonFile(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "appsettings.json"), optional: true)
+    .AddJsonFile(Path.Combine(appStorage.UserSettingsFolder, "appsettings.json"), optional: true)
+    .AddJsonFile(Path.Combine(appStorage.UserSettingsFolder, "appsettings.user.json"), optional: true);
 
-// this looks for appsettings.user.json in the user's ~/.dig directory
-builder.Configuration.AddJsonFile(path, optional: true)
-    .AddJsonFile(appStorage.UserSettingsFilePath, optional: true);
+if (OperatingSystem.IsWindows())
+{
+    LoggerProviderOptions.RegisterProviderOptions<EventLogSettings, EventLogLoggerProvider>(builder.Services);
+}
 
 var host = builder.ConfigureServices(appStorage)
     .Build();

--- a/src/dig/Program.cs
+++ b/src/dig/Program.cs
@@ -8,6 +8,8 @@ var builder = Host.CreateApplicationBuilder(args);
 
 // the non-web app builder doesn't bind to settings files automatically
 var path = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "appsettings.json");
+
+// this looks for appsettings.user.json in the user's ~/.dig directory
 builder.Configuration.AddJsonFile(path, optional: true)
     .AddJsonFile(appStorage.UserSettingsFilePath, optional: true);
 

--- a/src/dig/ServiceConfiguration.cs
+++ b/src/dig/ServiceConfiguration.cs
@@ -8,6 +8,13 @@ public static class ServiceConfiguration
 {
     public static HostApplicationBuilder ConfigureServices(this HostApplicationBuilder builder, AppStorage appStorage)
     {
+        // Check if the FileCacheDirectory is set in the configuration
+        if (string.IsNullOrEmpty(builder.Configuration.GetValue<string>("dig:FileCacheDirectory")))
+        {
+            // If not set, set it to the user settings folder
+            builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?> { { "dig:FileCacheDirectory", Path.Combine(appStorage.UserSettingsFolder, "store-cache") } });
+        }
+
         builder.Services.AddSingleton<StoreManager>()
             .AddSingleton<DynDnsService>()
             .AddSingleton<HostManager>()
@@ -18,8 +25,8 @@ public static class ServiceConfiguration
             .AddSingleton<NodeSyncService>()
             .AddSingleton<ChiaService>()
             .AddSingleton<StoreService>()
+            .AddSingleton<IObjectCache, FileCacheService>()
             .AddSingleton<StorePreCacheService>()
-            .AddSingleton<FileCacheService>()
             .AddSingleton<ServerCoinService>()
             .AddSingleton((provider) => appStorage)
             .AddHttpClient()

--- a/src/server/ServiceConfiguration.cs
+++ b/src/server/ServiceConfiguration.cs
@@ -10,6 +10,13 @@ public static class ServiceConfiguration
 {
     public static WebApplicationBuilder ConfigureServices(this WebApplicationBuilder builder, AppStorage appStorage)
     {
+        // Check if the FileCacheDirectory is set in the configuration
+        if (string.IsNullOrEmpty(builder.Configuration.GetValue<string>("dig:FileCacheDirectory")))
+        {
+            // If not set, set it to the user settings folder
+            builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?> { { "dig:FileCacheDirectory", Path.Combine(appStorage.UserSettingsFolder, "store-cache") } });
+        }
+
         if (builder.Environment.IsProduction())
         {
             builder.Services.AddApplicationInsightsTelemetry();

--- a/src/server/ServiceConfiguration.cs
+++ b/src/server/ServiceConfiguration.cs
@@ -55,7 +55,7 @@ public static class ServiceConfiguration
         // this is where configuration based services are added
         //
 
-        switch (builder.Configuration.GetValue("dig:CacheProvider", "Disabled"))
+        switch (builder.Configuration.GetValue("dig:CacheProvider", "FileSystem"))
         {
             case "Memory":
                 builder.Services.AddSingleton<IObjectCache, MemoryCacheService>();

--- a/src/shared/Services/AppStorage.cs
+++ b/src/shared/Services/AppStorage.cs
@@ -38,7 +38,6 @@ public class AppStorage
         }
     }
 
-    public string UserSettingsFilePath => Path.Combine(UserSettingsFolder, "appsettings.user.json");
     public string UserSettingsFolder => _folderPath;
 
     public static bool IsRunningAsService()

--- a/src/shared/Services/AppStorage.cs
+++ b/src/shared/Services/AppStorage.cs
@@ -1,4 +1,7 @@
+using System.Runtime.InteropServices;
+
 namespace dig;
+
 public class AppStorage
 {
     private readonly string _folderPath = string.Empty;
@@ -7,17 +10,26 @@ public class AppStorage
     {
         try
         {
-            _folderPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), folderName);
-            if (!Directory.Exists(_folderPath))
+            if (IsRunningAsService())
             {
-                Directory.CreateDirectory(_folderPath);
+                // when running as a service, redirect the user folder to temp
+                // which effectively means that there is no user settings or that
+                // the path to user settings have been passed as an argument to the service
+                // The file cache service will cache to temp as well
+                //
+                // this is a fallback for when the user settings are not available or set
+                _folderPath = Path.Combine(Path.GetTempPath(), folderName);
+            }
+            else
+            {
+                // the default folder is the user's profile folder
+                // e.g. C:\Users\username\folderName or /home/username/folderName
+                _folderPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), folderName);
             }
 
-            string sourceFileName = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "appsettings.json");
-            if (File.Exists(sourceFileName))
+            if (!Directory.Exists(UserSettingsFolder))
             {
-                // create the user settings file if it doesn't exit already
-                File.Copy(sourceFileName, UserSettingsFilePath, false);
+                Directory.CreateDirectory(UserSettingsFolder);
             }
         }
         catch (Exception ex)
@@ -26,14 +38,36 @@ public class AppStorage
         }
     }
 
-    public string UserSettingsFilePath => Path.Combine(_folderPath, "appsettings.user.json");
+    public string UserSettingsFilePath => Path.Combine(UserSettingsFolder, "appsettings.user.json");
     public string UserSettingsFolder => _folderPath;
+
+    public static bool IsRunningAsService()
+    {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            // Windows-specific check
+            var userName = System.Security.Principal.WindowsIdentity.GetCurrent().Name;
+
+            return userName.Equals(@"NT AUTHORITY\SYSTEM", StringComparison.OrdinalIgnoreCase) ||
+                   userName.Equals(@"NT AUTHORITY\NETWORK SERVICE", StringComparison.OrdinalIgnoreCase) ||
+                   userName.Equals(@"NT AUTHORITY\LOCAL SERVICE", StringComparison.OrdinalIgnoreCase);
+        }
+        else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) || RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        {
+            // Linux-specific check - simplistic for known service accounts
+            var userName = Environment.UserName;
+
+            return userName.Equals("root") || userName.Equals("nobody");
+        }
+
+        return false;
+    }
 
     public void Save(string name, string value)
     {
         try
         {
-            var filePath = Path.Combine(_folderPath, name);
+            var filePath = Path.Combine(UserSettingsFolder, name);
             File.WriteAllText(filePath, value);
         }
         catch (Exception ex)
@@ -46,7 +80,7 @@ public class AppStorage
     {
         try
         {
-            var filePath = Path.Combine(_folderPath, name);
+            var filePath = Path.Combine(UserSettingsFolder, name);
             if (File.Exists(filePath))
             {
                 File.Delete(filePath);
@@ -62,7 +96,7 @@ public class AppStorage
     {
         try
         {
-            var filePath = Path.Combine(_folderPath, name);
+            var filePath = Path.Combine(UserSettingsFolder, name);
             if (File.Exists(filePath))
             {
                 return File.ReadAllText(filePath);

--- a/src/shared/Services/Caching/FileCacheService.cs
+++ b/src/shared/Services/Caching/FileCacheService.cs
@@ -86,7 +86,7 @@ public class FileCacheService : IObjectCache
                 await File.WriteAllTextAsync(filePath, value.ToJson(), token);
             }
 
-            _logger.LogInformation("Cached {Key} of type {Type}", key, typeof(TItem).Name);
+            _logger.LogInformation("Cached {Key} of type {Type}", key.SanitizeForLog(), typeof(TItem).Name);
         }
     }
 
@@ -97,14 +97,14 @@ public class FileCacheService : IObjectCache
             foreach (var file in Directory.GetFiles(_cacheDirectory, "*"))
             {
                 var sanitizedPath = file.SanitizePath(_cacheDirectory);
-                _logger.LogInformation("Deleting file {File}", sanitizedPath);
+                _logger.LogInformation("Deleting file {File}", sanitizedPath.SanitizeForLog());
                 File.Delete(sanitizedPath);
             }
 
             foreach (var dir in Directory.GetDirectories(_cacheDirectory))
             {
                 var sanitizedPath = dir.SanitizePath(_cacheDirectory);
-                _logger.LogInformation("Deleting directory {Directory}", sanitizedPath);
+                _logger.LogInformation("Deleting directory {Directory}", sanitizedPath.SanitizeForLog());
                 Directory.Delete(sanitizedPath, true);
             }
         }
@@ -112,7 +112,7 @@ public class FileCacheService : IObjectCache
 
     public void RemoveStore(string storeId)
     {
-        _logger.LogWarning("Invalidating store {storeId}", storeId);
+        _logger.LogWarning("Invalidating store {storeId}", storeId.SanitizeForLog());
         var storeCacheDirectory = Path.Combine(_cacheDirectory, storeId).SanitizePath(_cacheDirectory);
 
         if (Directory.Exists(storeCacheDirectory))

--- a/src/shared/Services/LoginManager.cs
+++ b/src/shared/Services/LoginManager.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.DataProtection;
 using System.Dynamic;
 using System.Text;
 using System.Net.Http.Json;
+
 namespace dig;
 
 internal class LoginManager(IDataProtectionProvider provider,

--- a/src/shared/appsettings.examples.json
+++ b/src/shared/appsettings.examples.json
@@ -22,6 +22,7 @@
         "Comment": "This is the complete list of configurable settings.",
         "ChiaCertDirectory": "C:\\some_fully_qualified_path\\mainnet\\config\\ssl\\",
         "CacheProvider": "<Memory or FileSystem (default) or Disabled>",
+        "FileCacheDirectory": "<the fully qualified path to the file cache directory>",
         "FullNodeHost": "hostname_or_ip",
         "FullNodePort": 8555,
         "WalletHost": "hostname_or_ip",


### PR DESCRIPTION
Addresses https://github.com/Datalayer-Storage/Distributed-Internet-Gateway/issues/41

This PR does the following:

- Alters the windows installer so that the service runs as `NT AUTHORTY\Network Service` instead of `LocalSystem`. Network Service has far fewer permissions that Local System.
- Grants permissions for Network Service to have full control over `~/.dig` of the installing user so that it can manage the cache files there
- Creates `<FULLY EXPANDED USER HOME>/.dig/appsettings.user/json` and configures the windows service to read this at start up. Since the service does not run as the user, it gets the full path to the cache directory in this way.
- Ensure that the service code can correctly run without user or system permissions.

Note that for the service to use `CHIA_ROOT` it must be set as a system-wide environment variable, NOT as a user variable. NetworkService will not have the installing user's environment variables in its process.

Example user settings created by the installer:

```
{
  "dig":  {
    "FileCacheDirectory": "C:\\Users\\don\\.dig\\store-cache",
    "CacheProvider": "FileSystem"
  }
}
```