### PR TITLE
Feat/https

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -87,14 +87,7 @@
       "request": "launch",
       "preLaunchTask": "build",
       "program": "${workspaceFolder}/src/dig/bin/Debug/net8.0/dig.node.dll",
-      "args": [
-        "stores",
-        "sync",
-        "--mirror-reserve",
-        "300000002",
-        "--fee",
-        "5000000"
-      ],
+      "args": ["stores", "sync", "--fee", "5000000"],
       "cwd": "${workspaceFolder}/src/dig",
       "console": "integratedTerminal",
       "stopAtEntry": false,

--- a/src/dig/ServerCoinCommands/AddCoinCommand.cs
+++ b/src/dig/ServerCoinCommands/AddCoinCommand.cs
@@ -37,6 +37,13 @@ internal sealed class AddCoinCommand()
         var url = await dnsService.ResolveHostUrl(41410, Url, cts.Token);
         var fee = await chiaService.ResolveFee(Fee, serverReserve, cts.Token);
 
+        // if the user didn't supply a reserve amount AND the server is https, double the default reserve amount
+        if (ServerReserve is null && url.StartsWith("https", StringComparison.OrdinalIgnoreCase))
+        {
+            Console.WriteLine("Server is https. Doubling default reserve amount.");
+            serverReserve *= 2;
+        }
+
         if (serverCoinService.AddServer(Store, url, serverReserve, fee))
         {
             Console.WriteLine("Server coin create transaction submitted.");

--- a/src/dig/ServiceConfiguration.cs
+++ b/src/dig/ServiceConfiguration.cs
@@ -19,7 +19,7 @@ public static class ServiceConfiguration
             .AddSingleton<ChiaService>()
             .AddSingleton<StoreService>()
             .AddSingleton<StorePreCacheService>()
-            .AddSingleton<FileCacheService>()
+            .AddSingleton<IObjectCache, FileCacheService>()
             .AddSingleton<ServerCoinService>()
             .AddSingleton((provider) => appStorage)
             .AddHttpClient()

--- a/src/dig/Services/HostManager.cs
+++ b/src/dig/Services/HostManager.cs
@@ -2,11 +2,11 @@ using System.Net.Http.Json;
 
 namespace dig;
 
-internal class HostManager(DnsService denService,
+internal class HostManager(DnsService dnsService,
                             IHttpClientFactory httpClientFactory,
                             ILogger<HostManager> logger)
 {
-    private readonly DnsService _dnsService = denService;
+    private readonly DnsService _dnsService = dnsService;
     private readonly ILogger<HostManager> _logger = logger;
     private readonly HttpClient _httpClient = httpClientFactory.CreateClient("datalayer.storage");
 

--- a/src/dig/Services/StoreManager.cs
+++ b/src/dig/Services/StoreManager.cs
@@ -3,7 +3,7 @@ using chia.dotnet;
 namespace dig;
 
 internal class StoreManager(DataLayerProxy dataLayer,
-                        ILogger<StoreManager> logger)
+                            ILogger<StoreManager> logger)
 {
     private readonly DataLayerProxy _dataLayer = dataLayer;
     private readonly ILogger<StoreManager> _logger = logger;

--- a/src/dig/StoreCommands/AddStoreCommand.cs
+++ b/src/dig/StoreCommands/AddStoreCommand.cs
@@ -11,14 +11,14 @@ internal sealed class AddStoreCommand()
     [Option("f", "fee", ArgumentHelpName = "MOJOS", Description = "Fee override.")]
     public ulong? Fee { get; init; }
 
-    [Option("m", "mirror-reserve", Default = 300000001UL, ArgumentHelpName = "MOJOS", Description = "The amount to reserve with the mirror coin.")]
-    public ulong? MirrorReserve { get; init; } = 300000001UL;
+    [Option("m", "mirror-reserve", ArgumentHelpName = "MOJOS", Description = "The amount to reserve with the mirror coin.")]
+    public ulong? MirrorReserve { get; init; }
 
     [Option("p", "precache", Description = "Precache the store's data.")]
     public bool Precache { get; init; }
 
-    [Option("r", "server-reserve", Default = 300000001UL, ArgumentHelpName = "MOJOS", Description = "The amount to reserve with the server coin.")]
-    public ulong? ServerReserve { get; init; } = 300000001UL;
+    [Option("r", "server-reserve", ArgumentHelpName = "MOJOS", Description = "The amount to reserve with the server coin.")]
+    public ulong? ServerReserve { get; init; }
 
     [Option("u", "url", ArgumentHelpName = "URL", Description = "Server url override. If not provided, the server will use the configured url.")]
     public string? Url { get; init; }

--- a/src/dig/StoreCommands/SyncStoresCommand.cs
+++ b/src/dig/StoreCommands/SyncStoresCommand.cs
@@ -5,18 +5,19 @@ internal sealed class SyncStoresCommand()
     [Option("f", "fee", ArgumentHelpName = "MOJOS", Description = "Fee override.")]
     public ulong? Fee { get; init; }
 
-    [Option("m", "mirror-reserve", Default = 300000001UL, ArgumentHelpName = "MOJOS", Description = "The amount to reserve with each mirror coin.")]
-    public ulong? MirrorReserve { get; init; } = 300000001UL;
+    [Option("m", "mirror-reserve", ArgumentHelpName = "MOJOS", Description = "The amount to reserve with each mirror coin.")]
+    public ulong? MirrorReserve { get; init; }
 
     [Option("p", "precache", Description = "Precache the store's data.")]
     public bool Precache { get; init; }
 
-    [Option("r", "server-reserve", Default = 300000001UL, ArgumentHelpName = "MOJOS", Description = "The amount to reserve with each server coin.")]
-    public ulong? ServerReserve { get; init; } = 300000001UL;
+    [Option("r", "server-reserve", ArgumentHelpName = "MOJOS", Description = "The amount to reserve with each server coin.")]
+    public ulong? ServerReserve { get; init; }
 
     [CommandTarget]
     public async Task<int> Execute(NodeSyncService syncService,
                                     ChiaService chiaService,
+                                    DnsService dnsService,
                                     StorePreCacheService storeCacheService,
                                     IConfiguration configuration)
     {
@@ -27,21 +28,36 @@ internal sealed class SyncStoresCommand()
             return -1;
         }
 
-        ulong serverCoinReserve = ServerReserve ?? configuration.GetValue<ulong>("dig:ServerCoinReserveAmount", 0);
-        if (serverCoinReserve == 0)
+        ulong serverReserve = ServerReserve ?? configuration.GetValue<ulong>("dig:ServerCoinReserveAmount", 0);
+        if (serverReserve == 0)
         {
             Console.WriteLine("Server reserve amount is required.");
             return -1;
         }
 
-        using var cts = new CancellationTokenSource(10000);
+        using var cts = new CancellationTokenSource(60000);
         var fee = await chiaService.ResolveFee(Fee, mirrorCoinReserve, cts.Token);
 
+        var myDigUri = await dnsService.GetDigServerUri(cts.Token) ?? throw new Exception("No dig server uri found");
+        var myMirrorUri = await dnsService.GetMirrorUri(cts.Token) ?? throw new Exception("No mirror uri found");
+
+        Console.WriteLine($"Using dig server uri: {myDigUri}");
+        Console.WriteLine($"Using mirror uri: {myMirrorUri}");
+
+        // if the user didn't supply a reserve amount AND the server is https, double the default reserve amount
+        if (ServerReserve is null && myDigUri.StartsWith("https", StringComparison.OrdinalIgnoreCase))
+        {
+            Console.WriteLine("Server is https. Doubling default reserve amount.");
+            serverReserve *= 2;
+        }
+
         // pass CancellationToken.None as we want this to run as long as it takes (DL can be slow when busy)
-        var stores = await syncService.SyncWithDataLayer(mirrorCoinReserve,
-                                        serverCoinReserve,
-                                        fee,
-                                        CancellationToken.None);
+        var stores = await syncService.SyncWithDataLayer(myDigUri,
+                                                            myMirrorUri,
+                                                            mirrorCoinReserve,
+                                                            serverReserve,
+                                                            fee,
+                                                            CancellationToken.None);
 
         if (Precache)
         {

--- a/src/shared/Services/DnsService.cs
+++ b/src/shared/Services/DnsService.cs
@@ -24,7 +24,7 @@ public sealed class DnsService(IHttpClientFactory httpClientFactory,
     public async Task<string?> GetMirrorUri(CancellationToken stoppingToken)
     {
         var port = _configuration.GetValue("dig:DataLayerMirrorPort", 8575);
-        
+
         return await GetHostUri(port, stoppingToken);
     }
 
@@ -49,7 +49,8 @@ public sealed class DnsService(IHttpClientFactory httpClientFactory,
             return null;
         }
 
-        return $"http://{host}:{port}";
+        var scheme = _configuration.GetValue("dig:HostScheme", "http");
+        return $"{scheme}://{host}:{port}";
     }
 
     public async Task<string?> GetPublicIPAdress(CancellationToken stoppingToken)

--- a/src/shared/Services/LoginManager.cs
+++ b/src/shared/Services/LoginManager.cs
@@ -2,20 +2,17 @@ using Microsoft.AspNetCore.DataProtection;
 using System.Dynamic;
 using System.Text;
 using System.Net.Http.Json;
+
 namespace dig;
 
 internal class LoginManager(IDataProtectionProvider provider,
-                        AppStorage appStorage,
-                        DnsService dnsService,
-                        IHttpClientFactory httpClientFactory,
-                        ILogger<LoginManager> logger,
-                        IConfiguration configuration)
+                            AppStorage appStorage,
+                            IHttpClientFactory httpClientFactory,
+                            ILogger<LoginManager> logger)
 {
     private readonly IDataProtector _protector = provider.CreateProtector("DataLayer-Storage.datalayer.place.v3");
     private readonly AppStorage _appStorage = appStorage;
-    private readonly DnsService _dnsService = dnsService;
     private readonly ILogger<LoginManager> _logger = logger;
-    private readonly IConfiguration _configuration = configuration;
     private readonly HttpClient _httpClient = httpClientFactory.CreateClient("datalayer.storage");
 
     public async Task<string?> Login(string accessToken, string secretKey, CancellationToken stoppingToken = default)

--- a/src/shared/Services/NodeSyncService.cs
+++ b/src/shared/Services/NodeSyncService.cs
@@ -4,17 +4,15 @@ namespace dig;
 
 internal sealed class NodeSyncService(DataLayerProxy dataLayer,
                                         ServerCoinService serverCoinService,
-                                        DnsService dnsService,
-                                        ILogger<NodeSyncService> logger,
-                                        IConfiguration configuration)
+                                        ILogger<NodeSyncService> logger)
 {
     private readonly DataLayerProxy _dataLayer = dataLayer;
     private readonly ServerCoinService _serverCoinService = serverCoinService;
-    private readonly DnsService _dnsService = dnsService;
     private readonly ILogger<NodeSyncService> _logger = logger;
-    private readonly IConfiguration _configuration = configuration;
 
-    public async Task<IEnumerable<string>> SyncWithDataLayer(ulong mirrorReserveAmount,
+    public async Task<IEnumerable<string>> SyncWithDataLayer(string myDigUri,
+                                            string myMirrorUri,
+                                            ulong mirrorReserveAmount,
                                             ulong serverReserveAmount,
                                             ulong fee,
                                             CancellationToken stoppingToken)
@@ -24,12 +22,6 @@ internal sealed class NodeSyncService(DataLayerProxy dataLayer,
 
         _logger.LogInformation("Getting owned stores");
         var ownedStores = await _dataLayer.GetOwnedStores(stoppingToken);
-
-        var myMirrorUri = await _dnsService.GetMirrorUri(stoppingToken) ?? throw new Exception("No mirror uri found");
-        _logger.LogInformation("Using mirror uri: {uri}", myMirrorUri);
-
-        var myDigUri = await _dnsService.GetDigServerUri(stoppingToken) ?? throw new Exception("No dig server uri found");
-        _logger.LogInformation("Using dig server uri: {uri}", myDigUri);
 
         // DataLayer is the source of truth for subscriptions, so we need to make sure
         // we have a mirror for each subscription and a server coin for each subscription

--- a/src/shared/Services/StoreService.cs
+++ b/src/shared/Services/StoreService.cs
@@ -88,7 +88,7 @@ internal sealed class StoreService(DataLayerProxy dataLayer,
 
             var serverUriBuilder = new UriBuilder(url)
             {
-                Port = _configuration.GetValue("dig:DigPort", 41410)
+                Port = _configuration.GetValue("dig:DigServerPort", 41410)
             };
 
             if (!await AddServer(storeId, serverReserveAmount, fee, serverUriBuilder.ToString(), CancellationToken.None))

--- a/src/shared/appsettings.examples.json
+++ b/src/shared/appsettings.examples.json
@@ -31,8 +31,9 @@
         "ServerCoinExePath": "C:\\fully\\qualified\\path\\to\\server_coin.exe",
         "RpcTimeoutSeconds": 60,
         "ChiaConfigPath": "<custom fully qualified path to chia config>",
+        "HostScheme": "<http (default) or https depending on how the internet facing address is configured>",
         "HostName": "<the internet facing server hostname - if not provided will use whatsmyip as the host IP address>",
-        "DigPort": 41410,
+        "DigServerPort": 41410,
         "DataLayerMirrorPort": 8575,
         "WaitingForChangeDelayMinutes": 2,
         "NodeSyncJobEnabled": false,
@@ -45,7 +46,7 @@
         "AddMirrorReserveAmount": 300000001,
         "RunAsWindowsService": true,
         "DataLayerStorageUri": "https://api.datalayer.storage/",
-        "XchAddress": ""
+        "XchAddress": "leave blank or omit to look up dynamically"
     },
     "AllowedHosts": "*"
 }


### PR DESCRIPTION
https://github.com/Datalayer-Storage/Distributed-Internet-Gateway/issues/79

On the command line, if no server coin reserve amount is set AND the dig server url uses https, the default reserve amount is doubled.

Also adds the `HostScheme` configuration setting, which tells the cli what scheme to use for the mirror and server coins. It defaults to `http` since TLS requires additional setup.

```
{
    "dig": {
        "HostScheme": "https",
        "HostName": "dig.example.com",
        "DigServerPort": 8787,
        "DataLayerMirrorPort": 8575
    }
}
```

will result in
- https://dig.example.com:8787 for the server coin
- https://dig.example.com:8575 for the mirror coin


