### PR TITLE
Chore dotnet 8.0.7

### DIFF
--- a/publish.ps1
+++ b/publish.ps1
@@ -3,7 +3,7 @@ param(
 )
 # other runtimes that might work: https://learn.microsoft.com/en-us/dotnet/core/rid-catalog
 
-$version = "0.2.34"
+$version = "0.2.35"
 $fullName = "dig"
 $names = @("dig", "server")
 $src = "src"

--- a/publish.sh
+++ b/publish.sh
@@ -30,10 +30,10 @@ publish_project() {
     dotnet restore ./$src/$name/$name.csproj -r $runtime
 
     # fully standalone with embedded dotnet framework
-    dotnet publish ./$src/$name/$name.csproj -c Release -r $runtime --no-restore --framework $framework --self-contained true /p:PublishReadyToRunComposite=true /p:Version=$version /p:PublishSingleFile=true /p:PublishTrimmed=false /p:IncludeNativeLibrariesForSelfExtract=True /p:StripSymbols=true /p:PublishDir="bin/Release/$framework/$runtime" --output $outputRoot/standalone/$runtime
+    # dotnet publish ./$src/$name/$name.csproj -c Release -r $runtime --no-restore --framework $framework --self-contained true /p:PublishReadyToRunComposite=true /p:Version=$version /p:PublishSingleFile=true /p:PublishTrimmed=false /p:IncludeNativeLibrariesForSelfExtract=True /p:StripSymbols=true /p:PublishDir="bin/Release/$framework/$runtime" --output $outputRoot/standalone/$runtime
 
     # single file without embedded dotnet framework
-    # dotnet publish ./$src/$name/$name.csproj -c Release -r $runtime --no-restore --framework $framework --self-contained false /p:PublishReadyToRun=false /p:Version=$version /p:PublishSingleFile=true /p:PublishTrimmed=false /p:IncludeNativeLibrariesForSelfExtract=True /p:StripSymbols=true /p:PublishDir="bin/Release/$framework/$runtime" --output $outputRoot/singlefile/$runtime
+    dotnet publish ./$src/$name/$name.csproj -c Release -r $runtime --no-restore --framework $framework --self-contained false /p:PublishReadyToRun=false /p:Version=$version /p:PublishSingleFile=true /p:PublishTrimmed=false /p:IncludeNativeLibrariesForSelfExtract=True /p:StripSymbols=true /p:PublishDir="bin/Release/$framework/$runtime" --output $outputRoot/singlefile/$runtime
 }
 
 for runTime in "${runTimes[@]}"; do

--- a/src/dig/dig.csproj
+++ b/src/dig/dig.csproj
@@ -14,8 +14,8 @@
 
     <ItemGroup>
         <PackageReference Include="EasyPipes" Version="1.3.0" />
-        <PackageReference Include="Microsoft.AspNetCore.DataProtection" Version="8.0.5" />
-        <PackageReference Include="Microsoft.AspNetCore.DataProtection.Extensions" Version="8.0.5" />
+        <PackageReference Include="Microsoft.AspNetCore.DataProtection" Version="8.0.7" />
+        <PackageReference Include="Microsoft.AspNetCore.DataProtection.Extensions" Version="8.0.7" />
         <PackageReference Include="chia-dotnet" Version="4.0.0" />
         <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.0" />
         <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />

--- a/src/server/Views/Stores/Syncing.cshtml
+++ b/src/server/Views/Stores/Syncing.cshtml
@@ -34,11 +34,7 @@
 </style>
 
 <div class="spinner-container">
-    <div>
-        <div class="spinner-border spinner-border-custom" role="status" aria-hidden="true"></div>
-        <span class="syncing-text">Syncing...</span>
-    <div>
-    <div>
-        Generation @Model.DataLayerSyncStatus.Generation of @Model.DataLayerSyncStatus.TargetGeneration
-    </div>
+    <div class="spinner-border spinner-border-custom" role="status" aria-hidden="true"></div>
+    <span class="syncing-text">Syncing...</span>
+    <div>Generation @Model.DataLayerSyncStatus.Generation of @Model.DataLayerSyncStatus.TargetGeneration</div>
 </div>

--- a/src/server/server.csproj
+++ b/src/server/server.csproj
@@ -14,17 +14,17 @@
         <PackageReference Include="chia-dotnet" Version="4.0.0" />
         <PackageReference Include="EasyPipes" Version="1.3.0" />
         <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.22.0" />
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.5" />
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.7" />
         <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="8.0.0" />
         <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="8.5.0" />
+        <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="8.7.0" />
         <PackageReference Include="MimeTypes" Version="2.5.2">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="QRCoder" Version="1.4.3" />
+        <PackageReference Include="QRCoder" Version="1.6.0" />
 
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
 
         <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     </ItemGroup>


### PR DESCRIPTION
upgrade dotnet deps to 8.0.7

plus i was working in the wrong branch and changed these two things which need to go to dev anyways

- change the default publish.sh to NOT embed the dotnet framework. Was causing an issue with an unmanaged ssl dependency on ubunut
- clear the file cache when a store is removed